### PR TITLE
Upgrade to 0.16-rc.1 and add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,13 @@ description = "Tools for spawning entity hierarchies in Bevy"
 tags = ["bevy", "ecs"]
 
 [dependencies]
-bevy_ecs = { version = "0.15", default-features = false }
-bevy_hierarchy = { version = "0.15", default-features = false }
+bevy_ecs = { version = "0.16.0-rc.1", default-features = false }
+bevy_platform_support = { version = "0.16.0-rc.1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-bevy = { version = "0.15" }
+bevy = { version = "0.16.0-rc.1" }
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Release notes for `i-cant-believe-its-not-bsn`
 
+## 0.4
+
+- now compatible with Bevy 0.16
+- added `no_std` support
+
 ## 0.3
 
 - added declarative templates with a `template` macro

--- a/examples/super-sheep-counter-2000.rs
+++ b/examples/super-sheep-counter-2000.rs
@@ -77,7 +77,7 @@ fn visible_if(condition: bool) -> Visibility {
 
 // A global observer which responds to button clicks.
 fn observe_buttons(
-    mut trigger: Trigger<Pointer<Up>>,
+    mut trigger: Trigger<Pointer<Released>>,
     buttons: Query<&Button>,
     sheep: Query<Entity, With<Sheep>>,
     mut commands: Commands,
@@ -88,7 +88,7 @@ fn observe_buttons(
         }
         Some(Button::Decrement) => {
             if let Some(sheep) = sheep.iter().next() {
-                commands.entity(sheep).despawn_recursive();
+                commands.entity(sheep).despawn();
             }
         }
         _ => {}

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -1,11 +1,11 @@
 use core::marker::PhantomData;
 
 use bevy_ecs::{
-    component::{ComponentHooks, ComponentId, StorageType},
+    component::{ComponentHooks, HookContext, Immutable, StorageType},
     prelude::*,
-    world::{Command, DeferredWorld},
+    system::Command,
+    world::DeferredWorld,
 };
-use bevy_hierarchy::BuildChildren;
 
 /// A component that, when added to an entity, will add a child entity with the given bundle.
 ///
@@ -39,6 +39,8 @@ use bevy_hierarchy::BuildChildren;
 pub struct WithChild<B: Bundle>(pub B);
 
 impl<B: Bundle> Component for WithChild<B> {
+    type Mutability = Immutable;
+
     /// This is a sparse set component as it's only ever added and removed, never iterated over.
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
 
@@ -52,8 +54,7 @@ impl<B: Bundle> Component for WithChild<B> {
 /// Generates a [`WithChildCommand`].
 fn with_child_hook<B: Bundle>(
     mut world: DeferredWorld<'_>,
-    entity: Entity,
-    _component_id: ComponentId,
+    HookContext { entity, .. }: HookContext,
 ) {
     // Component hooks can't perform structural changes, so we need to rely on commands.
     world.commands().queue(WithChildCommand {
@@ -144,6 +145,8 @@ pub struct WithChildren<B: Bundle, I: IntoIterator<Item = B>>(pub I);
 impl<B: Bundle, I: IntoIterator<Item = B> + Send + Sync + 'static> Component
     for WithChildren<B, I>
 {
+    type Mutability = Immutable;
+
     /// This is a sparse set component as it's only ever added and removed, never iterated over.
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
 
@@ -157,8 +160,7 @@ impl<B: Bundle, I: IntoIterator<Item = B> + Send + Sync + 'static> Component
 /// Generates a [`WithChildrenCommand`].
 fn with_children_hook<B: Bundle, I: IntoIterator<Item = B> + Send + Sync + 'static>(
     mut world: DeferredWorld<'_>,
-    entity: Entity,
-    _component_id: ComponentId,
+    HookContext { entity, .. }: HookContext,
 ) {
     // Component hooks can't perform structural changes, so we need to rely on commands.
     world.commands().queue(WithChildrenCommand {
@@ -201,8 +203,9 @@ impl<B: Bundle, I: IntoIterator<Item = B> + Send + Sync + 'static> Command
 
 #[cfg(test)]
 mod tests {
-    use bevy_ecs::system::RunSystemOnce;
-    use bevy_hierarchy::Children;
+    use alloc::{vec, vec::Vec};
+
+    use bevy_ecs::{hierarchy::Children, system::RunSystemOnce};
 
     use super::*;
 
@@ -259,7 +262,7 @@ mod tests {
         assert_eq!(children.len(), 3);
 
         for (i, child_entity) in children.iter().enumerate() {
-            assert_eq!(world.get::<B>(*child_entity), Some(&B(i as u8)));
+            assert_eq!(world.get::<B>(child_entity), Some(&B(i as u8)));
         }
     }
 
@@ -278,7 +281,7 @@ mod tests {
         assert_eq!(children.len(), 7);
 
         for (i, child_entity) in children.iter().enumerate() {
-            assert_eq!(world.get::<B>(*child_entity), Some(&B(i as u8)));
+            assert_eq!(world.get::<B>(child_entity), Some(&B(i as u8)));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate alloc;
 
 mod hierarchy;
 pub use hierarchy::*;

--- a/src/maybe.rs
+++ b/src/maybe.rs
@@ -1,9 +1,10 @@
 use core::marker::PhantomData;
 
 use bevy_ecs::{
-    component::{ComponentHooks, ComponentId, StorageType},
+    component::{ComponentHooks, HookContext, Immutable, StorageType},
     prelude::*,
-    world::{Command, DeferredWorld},
+    system::Command,
+    world::DeferredWorld,
 };
 
 /// A component that when added to an entity, will be removed from the entity and replaced with its contents if [`Some`].
@@ -18,7 +19,7 @@ use bevy_ecs::{
 /// use bevy_ecs::prelude::*;
 /// use bevy_ecs::system::RunSystemOnce;
 /// use i_cant_believe_its_not_bsn::Maybe;
-
+///
 /// #[derive(Component)]
 /// struct A;
 ///
@@ -55,6 +56,8 @@ use bevy_ecs::{
 pub struct Maybe<B: Bundle>(pub Option<B>);
 
 impl<B: Bundle> Component for Maybe<B> {
+    type Mutability = Immutable;
+
     /// This is a sparse set component as it's only ever added and removed, never iterated over.
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
 
@@ -88,7 +91,7 @@ impl<B: Bundle> Default for Maybe<B> {
 /// A hook that runs whenever [`Maybe`] is added to an entity.
 ///
 /// Generates a [`MaybeCommand`].
-fn maybe_hook<B: Bundle>(mut world: DeferredWorld<'_>, entity: Entity, _component_id: ComponentId) {
+fn maybe_hook<B: Bundle>(mut world: DeferredWorld<'_>, HookContext { entity, .. }: HookContext) {
     // Component hooks can't perform structural changes, so we need to rely on commands.
     world.commands().queue(MaybeCommand {
         entity,

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,14 @@
-use std::collections::{HashMap, HashSet};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use bevy_ecs::{component::ComponentId, prelude::*};
-use bevy_hierarchy::prelude::*;
+use bevy_platform_support::{
+    collections::{HashMap, HashSet},
+    hash::FixedHasher,
+};
 
 /// A template is an ordered collection of heterogenous prototypes, which can be
 /// inserted into the world. Returned by the [`template`] macro.
@@ -74,7 +81,7 @@ pub trait CommandsTemplateExt {
     fn build(&mut self, template: Template);
 }
 
-impl<'w, 's> CommandsTemplateExt for Commands<'w, 's> {
+impl CommandsTemplateExt for Commands<'_, '_> {
     fn build(&mut self, template: Template) {
         self.queue(BuildTemplateCommand(template));
     }
@@ -158,7 +165,7 @@ impl<B: Bundle> Prototype for Fragment<B> {
 
     fn build(self: Box<Self>, world: &mut World, receipt: &mut Receipt) {
         // Collect the set of components in the bundle
-        let mut components = HashSet::new();
+        let mut components = HashSet::default();
         B::get_component_ids(world.components(), &mut |maybe_id| {
             if let Some(id) = maybe_id {
                 components.insert(id);
@@ -184,7 +191,7 @@ impl<B: Bundle> Prototype for Fragment<B> {
         // Build the children
         let num_children = self.children.len();
         let mut children = Vec::with_capacity(num_children);
-        let mut child_receipts = HashMap::with_capacity(num_children);
+        let mut child_receipts = HashMap::with_capacity_and_hasher(num_children, FixedHasher);
         let mut i = 0;
         for child in self.children {
             // Compute the anchor for this child, using it's name if supplied or an auto-incrementing
@@ -209,13 +216,26 @@ impl<B: Bundle> Prototype for Fragment<B> {
             child_receipts.insert(child_anchor, child_receipt);
         }
 
+        // Remove any existing children
+        let old_children = world
+            .entity(entity_id)
+            .get::<Children>()
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
+
+        for child in old_children {
+            world.entity_mut(child).remove::<ChildOf>();
+        }
+
         // Position the children beneith the entity
-        world.entity_mut(entity_id).replace_children(&children);
+        world.entity_mut(entity_id).add_children(&children);
 
         // Clear any remaining orphans
         for receipt in receipt.children.values() {
             if let Some(entity) = receipt.target {
-                world.entity_mut(entity).despawn_recursive();
+                world.entity_mut(entity).despawn();
             }
         }
 
@@ -232,7 +252,7 @@ impl<B: Bundle> IntoIterator for Fragment<B> {
     type IntoIter = core::iter::Once<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        std::iter::once(Box::new(self) as Box<_>)
+        core::iter::once(Box::new(self) as Box<_>)
     }
 }
 


### PR DESCRIPTION
# Objective

- Upgrade to Bevy 0.16-rc.1
- Add `no_std` support

## Solution

Migrated as the compiler instructed.

---

## Notes

### `replace_children` is gone

The removal of `EntityWorldMut::replace_children` was the worst part of an otherwise simple migration. 
```rust
// Before
world.entity_mut(entity_id).replace_children(&children);

// After
let old_children = world
    .entity(entity_id)
    .get::<Children>()
    .into_iter()
    .flatten()
    .copied()
    .collect::<Vec<_>>();

for child in old_children {
    world.entity_mut(child).remove::<ChildOf>();
}

world.entity_mut(entity_id).add_children(&children);
```

Might be worth re-adding `replace_children` and `remove_children` methods to simplify migration.

### `no_std` Effort

Found this to be a _very_ simple crate to make `no_std`. And since it doesn't rely on any `std` features at all, it doesn't need any of the feature flags we'd typically recommend. Very clean!