### PR TITLE
Upgrade to Bevy 0.16.1 (crate version: v0.4.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,13 @@ description = "Tools for spawning entity hierarchies in Bevy"
 keywords = ["bevy", "ecs"]
 
 [dependencies]
-bevy_ecs = { version = "0.16.0-rc.1", default-features = false }
-bevy_platform_support = { version = "0.16.0-rc.1", default-features = false, features = ["alloc"] }
+bevy_ecs = { version = "0.16.1", default-features = false }
+bevy_platform_support = { version = "0.16.0-rc.4", default-features = false, features = [
+    "alloc",
+] }
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.1" }
+bevy = { version = "0.16.1" }
 
 [lints.clippy]
 alloc_instead_of_core = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 repository = "https://github.com/Leafwing-Studios/i-cant-believe-its-not-bsn"
 license = "MIT OR Apache-2.0"
 description = "Tools for spawning entity hierarchies in Bevy"
-tags = ["bevy", "ecs"]
+keywords = ["bevy", "ecs"]
 
 [dependencies]
 bevy_ecs = { version = "0.16.0-rc.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "i-cant-believe-its-not-bsn"
 authors = ["Alice I. Cecile"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/Leafwing-Studios/i-cant-believe-its-not-bsn"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,44 @@ Just add it as a component holding the bundle you want to use to spawn the child
 
 These helper components are extremely useful when you just want to insert a tree of entities declaratively.
 
+### In Required Components
+
+Also, these components can be used to spawn children entities with required components:
+
+```rust
+use bevy::prelude::*;
+use i_cant_believe_its_not_bsn::WithChild;
+
+#[derive(Component)]
+#[require(Transform, WithChild<PlayerHead>, WithChild<PlayerBody>)]
+struct Player;
+
+#[derive(Component, Default)]
+struct PlayerHead;
+
+#[derive(Component, Default)]
+struct PlayerBody;
+
+fn main() {
+    let mut app: App = App::new();
+    app.add_systems(Startup, spawn_player);
+    app.update();
+
+    let world: &mut World = app.world_mut();
+    let player_entity: Entity = world
+        .query_filtered::<Entity, With<Player>>()
+        .single(world)
+        .unwrap();
+
+    let children: &Children = world.get::<Children>(player_entity).unwrap();
+    assert_eq!(children.len(), 2);
+}
+
+fn spawn_player(mut commands: Commands) {
+    commands.spawn(Player);
+}
+```
+
 ## The Template Macro
 
 Alternatively, you can use the `template!()` macro, which is very similar to the proposed BSN syntax. Arbitrary data can be passed into the macro using normal rust blocks. It returns portable `Template` values, which can be spliced into other templates using `@{ ... }`.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ The macro returns portable `Template` values, which can be spliced into other te
 
 Not only is the macro declarative and composable, it also supports basic incrementalization (doing partial updates to the ecs rather than rebuilding from scratch).
 Building the same macro multiple times with `commands.build(template)` does only the work necessary to bring the ecs into alignment with the template.
+
+## Bevy Version
+
+Different versions of this crate support different versions of Bevy Engine:
+
+| Crate Version | Bevy Version |
+| ------------- | ------------ |
+| 0.1           | 0.14         |
+| 0.2, 0.3      | 0.15         |
+| 0.4           | 0.16.1       |

--- a/README.md
+++ b/README.md
@@ -2,29 +2,23 @@
 
 Ergonomic ways to spawn Bevy entity hierarchies.
 
-Eagerly [waiting for BSN](https://github.com/bevyengine/bevy/discussions/14437)?
-Really wish you could spawn hierarchies with less boilerplate?
-Just want to define some reusable widget types for `bevy_ui` in code?
+Eagerly [waiting for BSN](https://github.com/bevyengine/bevy/discussions/14437)? Really wish you could spawn hierarchies with less boilerplate? Just want to define some reusable widget types for `bevy_ui` in code?
 
 This crate is here to help!
 
-# Helper Components
+## Helper Components
 
 You can use the helper component `WithChild`, and its iterator sibling, `WithChildren`, to embed hierarchy information in normal bundles.
 
-Just add it as a component holding the bundle you want to use to spawn the child, and you're off to the races.
-A component hook will see that this component has been added, extract the data from your `WithChild` component, and then move it into a child, cleaning itself up as it goes.
+Just add it as a component holding the bundle you want to use to spawn the child, and you're off to the races. A component hook will see that this component has been added, extract the data from your `WithChild` component, and then move it into a child, cleaning itself up as it goes.
 
 These helper components are extremely useful when you just want to insert a tree of entities declaratively.
 
-# The Template Macro
+## The Template Macro
 
-Alternatively you can use the `template!()` macro, which is very similar to the proposed bsn syntax.
-Arbitrary data can be passed into the macro using normal rust blocks.
-The macro returns portable `Template` values, which can be spliced into other templates using `@{ ... }`.
+Alternatively, you can use the `template!()` macro, which is very similar to the proposed BSN syntax. Arbitrary data can be passed into the macro using normal rust blocks. It returns portable `Template` values, which can be spliced into other templates using `@{ ... }`.
 
-Not only is the macro declarative and composable, it also supports basic incrementalization (doing partial updates to the ecs rather than rebuilding from scratch).
-Building the same macro multiple times with `commands.build(template)` does only the work necessary to bring the ecs into alignment with the template.
+Not only is this macro declarative and composable - it also supports basic incrementalization (doing partial updates to the ECS rather than rebuilding from scratch)! Building the same macro multiple times with `commands.build(template)` does the minimal amount of work necessary to bring the ECS into alignment with the template.
 
 ## Bevy Version
 

--- a/src/maybe.rs
+++ b/src/maybe.rs
@@ -36,7 +36,7 @@ use bevy_ecs::{
 ///             maybe_a: Maybe::new(A),
 ///         })
 ///         .id()
-/// });
+/// }).unwrap();
 /// let entity_ref = world.get_entity(entity_with_component).unwrap();
 /// assert!(entity_ref.contains::<A>());
 /// assert!(!entity_ref.contains::<Maybe<A>>());
@@ -47,7 +47,7 @@ use bevy_ecs::{
 ///             maybe_a: Maybe::NONE,
 ///         })
 ///         .id()
-/// });
+/// }).unwrap();
 /// let entity_ref = world.get_entity(entity_without_component).unwrap();
 /// assert!(!entity_ref.contains::<A>());
 /// assert!(!entity_ref.contains::<Maybe<A>>());


### PR DESCRIPTION
So, I want to update my project to Bevy 0.16.1, but this crate isn't updated yet. So, I decided to do it myself!

## Changes

Here's a lil summary of my changes: 

- Updated Bevy to 0.16.1
- Fixed a test to properly unwrap
- Changed the crate's version to `0.4.0`

In true ADHD fashion, I also did some cleanup:

- Fixed `Cargo.toml` to use `package.keywords` key instead of the non-existent key `package.tags` 
- README stuff
	- Added a version table
	- I also did a formatting pass
	- Added a new doctest using required components

## Checklist

- [x] Update to Bevy 0.16.1
- [x] Document crate version to Bevy version mapping
- [x] Run all tests and examples
	- Ended up fixing the `crate::maybe::Maybe` doctest for the new Bevy update
	- ...and adding another basic test to the README lol

## Note

If you want any changes, or want the ADHD changes in another PR, please let me know! Thank you for the great project! :D